### PR TITLE
Feature/add project menu

### DIFF
--- a/app/controllers/github_repos_controller.rb
+++ b/app/controllers/github_repos_controller.rb
@@ -7,6 +7,8 @@ class GithubReposController < ApplicationController
   end
 
   def create
+    @github_repo = GithubRepo.create(github_repo_params)
+    redirect_to index_github_repos_path(@github_repo.project)
   end
 
   def index_in_project

--- a/app/controllers/github_repos_controller.rb
+++ b/app/controllers/github_repos_controller.rb
@@ -26,6 +26,10 @@ class GithubReposController < ApplicationController
   end
 
   def destroy
+    @github_repo = GithubRepo.find(params[:id])
+    @project = @github_repo.project
+    @github_repo.destroy
+    redirect_to index_github_repos_path(@project)
   end
 
   private

--- a/app/controllers/github_repos_controller.rb
+++ b/app/controllers/github_repos_controller.rb
@@ -25,4 +25,9 @@ class GithubReposController < ApplicationController
 
   def destroy
   end
+
+  private
+    def github_repo_params
+      params.require(:github_repo).permit(:project_id, :name, :owner, :user, :pass)
+    end
 end

--- a/app/controllers/github_repos_controller.rb
+++ b/app/controllers/github_repos_controller.rb
@@ -23,6 +23,9 @@ class GithubReposController < ApplicationController
   end
 
   def update
+    @github_repo = GithubRepo.find(params[:id])
+    @github_repo.update(github_repo_params)
+    redirect_to index_github_repos_path(@github_repo.project)
   end
 
   def destroy

--- a/app/controllers/github_repos_controller.rb
+++ b/app/controllers/github_repos_controller.rb
@@ -1,0 +1,28 @@
+class GithubReposController < ApplicationController
+  unloadable
+
+  def new_in_project
+    @project = Project.find(params[:id])
+    @github_repo = @project.github_repos.build
+  end
+
+  def create
+  end
+
+  def index_in_project
+    @project = Project.find(params[:id])
+    @github_repos = @project.github_repos
+    render template: 'github_repos/index'
+  end
+
+  def edit
+    @github_repo = GithubRepo.find(params[:id])
+    @project = @github_repo.project
+  end
+
+  def update
+  end
+
+  def destroy
+  end
+end

--- a/app/helpers/github_repos_helper.rb
+++ b/app/helpers/github_repos_helper.rb
@@ -1,0 +1,2 @@
+module GithubReposHelper
+end

--- a/app/models/github_repo.rb
+++ b/app/models/github_repo.rb
@@ -1,0 +1,5 @@
+class GithubRepo < ActiveRecord::Base
+  unloadable
+
+  belongs_to :project
+end

--- a/app/models/github_repo.rb
+++ b/app/models/github_repo.rb
@@ -1,5 +1,6 @@
 class GithubRepo < ActiveRecord::Base
   unloadable
+  attr_accessible :project_id, :name, :owner, :user, :pass
 
   belongs_to :project
 end

--- a/app/views/github_repos/_form.html.erb
+++ b/app/views/github_repos/_form.html.erb
@@ -1,0 +1,5 @@
+<%= f.hidden_field :project_id %>
+<p><%= f.text_field :name, size: 80, maxlength: 255, required: true, label: "GitHub上のレポジトリの名前" %></p>
+<p><%= f.text_field :owner, size: 80, maxlength: 255, required: true, label: "GitHub上でのレポジトリの所有者" %></p>
+<p><%= f.text_field :user, size: 80, maxlength: 255, required: true, label: "レポジトリにアクセスするユーザの名前" %></p>
+<p><%= f.text_field :pass, size: 80, maxlength: 255, required: true, label: "レポジトリにアクセスするユーザのパスワード" %></p>

--- a/app/views/github_repos/edit.html.erb
+++ b/app/views/github_repos/edit.html.erb
@@ -1,0 +1,4 @@
+<h3><%= l(:button_edit) %></h3>
+<%= labelled_form_for @github_repo, :html => {:id => 'github_repo-form', :multipart => true} do |f| %>
+form goes here
+<% end %>

--- a/app/views/github_repos/edit.html.erb
+++ b/app/views/github_repos/edit.html.erb
@@ -1,4 +1,13 @@
 <h3><%= l(:button_edit) %></h3>
 <%= labelled_form_for @github_repo, :html => {:id => 'github_repo-form', :multipart => true} do |f| %>
-form goes here
+  <div class="box tabular">
+    <div id="all_attributes">
+      <%= render :partial => 'github_repos/form', :locals => {:f => f} %>
+    </div>
+  </div>
+  <%= submit_tag l(:button_submit) %>
+<% end %>
+
+<% content_for :header_tags do %>
+    <%= stylesheet_link_tag 'github_repo', :plugin => 'redmine_github_issue' %>
 <% end %>

--- a/app/views/github_repos/edit.html.erb
+++ b/app/views/github_repos/edit.html.erb
@@ -1,5 +1,5 @@
 <h3><%= l(:button_edit) %></h3>
-<%= labelled_form_for @github_repo, :html => {:id => 'github_repo-form', :multipart => true} do |f| %>
+<%= labelled_form_for @github_repo, url: github_repo_path(@github_repo), html: {method: :put, id: 'github_repo-form', multipart: true} do |f| %>
   <div class="box tabular">
     <div id="all_attributes">
       <%= render :partial => 'github_repos/form', :locals => {:f => f} %>

--- a/app/views/github_repos/index.html.erb
+++ b/app/views/github_repos/index.html.erb
@@ -28,3 +28,7 @@
             new_github_repo_path(@project),
             :class => 'icon icon-add') %>
 </p>
+
+<% content_for :header_tags do %>
+    <%= stylesheet_link_tag 'github_repo', :plugin => 'redmine_github_issue' %>
+<% end %>

--- a/app/views/github_repos/index.html.erb
+++ b/app/views/github_repos/index.html.erb
@@ -1,0 +1,30 @@
+<div class="autoscroll">
+  <table class="list">
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>name</th>
+        <th>owner</th>
+        <th>username</th>
+        <th>password</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% for repo in @github_repos %>
+        <tr>
+          <td><%= link_to repo.id, edit_github_repo_path(repo) %></td>
+          <td><%= link_to repo.name, edit_github_repo_path(repo) %></td>
+          <td><%= repo.owner %></td>
+          <td><%= repo.user %></td>
+          <td><%= repo.pass %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+
+<p>
+<%= link_to("新しいGitHubレポジトリを追加",
+            new_github_repo_path(@project),
+            :class => 'icon icon-add') %>
+</p>

--- a/app/views/github_repos/index.html.erb
+++ b/app/views/github_repos/index.html.erb
@@ -2,7 +2,6 @@
   <table class="list">
     <thead>
       <tr>
-        <th>#</th>
         <th>name</th>
         <th>owner</th>
         <th>username</th>
@@ -13,7 +12,6 @@
     <tbody>
       <% for repo in @github_repos %>
         <tr>
-          <td><%= repo.id %></td>
           <td><%= repo.name %></td>
           <td><%= repo.owner %></td>
           <td><%= repo.user %></td>

--- a/app/views/github_repos/index.html.erb
+++ b/app/views/github_repos/index.html.erb
@@ -7,16 +7,21 @@
         <th>owner</th>
         <th>username</th>
         <th>password</th>
+        <th></th>
       </tr>
     </thead>
     <tbody>
       <% for repo in @github_repos %>
         <tr>
-          <td><%= link_to repo.id, edit_github_repo_path(repo) %></td>
-          <td><%= link_to repo.name, edit_github_repo_path(repo) %></td>
+          <td><%= repo.id %></td>
+          <td><%= repo.name %></td>
           <td><%= repo.owner %></td>
           <td><%= repo.user %></td>
           <td><%= repo.pass %></td>
+          <td class="buttons">
+            <%= link_to(l(:button_edit), edit_github_repo_path(repo), :class => 'icon icon-edit') %>
+            <%= delete_link github_repo_path(repo) %>
+          </td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/github_repos/new_in_project.html.erb
+++ b/app/views/github_repos/new_in_project.html.erb
@@ -1,5 +1,10 @@
 <%= title "新しいGitHubレポジトリ" %>
 
 <%= labelled_form_for @github_repo, :html => {:id => 'github_repo-form', :multipart => true} do |f| %>
-form goes here
+  <div class="box tabular">
+    <div id="all_attributes">
+      <%= render :partial => 'github_repos/form', :locals => {:f => f} %>
+    </div>
+  </div>
+  <%= submit_tag l(:button_create) %>
 <% end %>

--- a/app/views/github_repos/new_in_project.html.erb
+++ b/app/views/github_repos/new_in_project.html.erb
@@ -8,3 +8,7 @@
   </div>
   <%= submit_tag l(:button_create) %>
 <% end %>
+
+<% content_for :header_tags do %>
+    <%= stylesheet_link_tag 'github_repo', :plugin => 'redmine_github_issue' %>
+<% end %>

--- a/app/views/github_repos/new_in_project.html.erb
+++ b/app/views/github_repos/new_in_project.html.erb
@@ -1,0 +1,5 @@
+<%= title "新しいGitHubレポジトリ" %>
+
+<%= labelled_form_for @github_repo, :html => {:id => 'github_repo-form', :multipart => true} do |f| %>
+form goes here
+<% end %>

--- a/app/views/github_repos/show.html.erb
+++ b/app/views/github_repos/show.html.erb
@@ -1,1 +1,0 @@
-<%= @github_repo.name %>

--- a/app/views/github_repos/show.html.erb
+++ b/app/views/github_repos/show.html.erb
@@ -1,0 +1,1 @@
+<%= @github_repo.name %>

--- a/assets/stylesheets/github_repo.css
+++ b/assets/stylesheets/github_repo.css
@@ -1,0 +1,4 @@
+
+#github_repo-form .tabular label {
+    width: 300px;
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,4 @@
 
 resources :github_repos, except: ['new', 'index', 'show']
 get 'projects/:id/github_repos/new', to: 'github_repos#new_in_project', as: 'new_github_repo'
-get 'projects/:id/github_repos', to: 'github_repos#index_in_project'
+get 'projects/:id/github_repos', to: 'github_repos#index_in_project', as: 'index_github_repos'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,2 +1,6 @@
 # Plugin's routes
 # See: http://guides.rubyonrails.org/routing.html
+
+resources :github_repos, except: ['new', 'index', 'show']
+get 'projects/:id/github_repos/new', to: 'github_repos#new_in_project', as: 'new_github_repo'
+get 'projects/:id/github_repos', to: 'github_repos#index_in_project'

--- a/db/migrate/001_create_github_repos.rb
+++ b/db/migrate/001_create_github_repos.rb
@@ -1,0 +1,14 @@
+class CreateGithubRepos < ActiveRecord::Migration
+  def change
+    create_table :github_repos do |t|
+      t.integer :project_id, null: false
+
+      t.string :name, null: false
+      t.string :owner, null: false
+      t.string :user, null: false
+      t.string :pass, null: false
+
+      t.timestamps null: true
+    end
+  end
+end

--- a/init.rb
+++ b/init.rb
@@ -1,6 +1,17 @@
 require "redmine"
+require "project"
 
 require_dependency 'redmine_github_issue/hooks'
+
+module ProjectPatch
+  def self.included(base)
+    # Same as typing in the class
+    base.class_eval do
+      unloadable # Send unloadable so it will not be unloaded in development
+      has_many :github_repos
+    end
+  end
+end
 
 Redmine::Plugin.register :redmine_github_issue do
   name 'Redmine Github Issue'
@@ -12,3 +23,5 @@ Redmine::Plugin.register :redmine_github_issue do
 
   GITHUB_CONFIG = YAML.load_file("#{Rails.root.to_s}/plugins/redmine_github_issue/config/github.yml")
 end
+
+Project.send(:include, ProjectPatch)

--- a/init.rb
+++ b/init.rb
@@ -21,6 +21,9 @@ Redmine::Plugin.register :redmine_github_issue do
   url 'https://github.com/TakayukiSakai/redmine_github_issue'
   author_url 'https://github.com/TakayukiSakai'
 
+  permission :github_repos, { :github_repos => [:index_in_project] }, :public => true
+  menu :project_menu, :github_repos, { controller: 'github_repos', action: 'index_in_project' }, caption: 'GitHub'
+
   GITHUB_CONFIG = YAML.load_file("#{Rails.root.to_s}/plugins/redmine_github_issue/config/github.yml")
 end
 

--- a/test/functional/github_repos_controller_test.rb
+++ b/test/functional/github_repos_controller_test.rb
@@ -1,0 +1,8 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+class GithubReposControllerTest < ActionController::TestCase
+  # Replace this with your real tests.
+  def test_truth
+    assert true
+  end
+end

--- a/test/unit/github_repo_test.rb
+++ b/test/unit/github_repo_test.rb
@@ -1,0 +1,9 @@
+require File.expand_path('../../test_helper', __FILE__)
+
+class GithubRepoTest < ActiveSupport::TestCase
+
+  # Replace this with your real tests.
+  def test_truth
+    assert true
+  end
+end


### PR DESCRIPTION
Add "GitHub" menu into project menu.

In the menu, github repositories associated with the project are shown. You can create, edit and delete github repositories which are associated with the project, too.
One project can have multiple github repositories, while a repository must have only one project. (One to Many relationship.)

I18n is not done yet. Only Japanese is supported.
